### PR TITLE
Exclude web/.gitkeep from PyPI wheel distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-02-22
+
+### Fixed
+
+- **PyPI wheel packaging**: Fixed duplicate `.gitkeep` file in wheel that caused PyPI upload rejection. Changed wheel build configuration to use `only-include` for Python files, preventing the `.gitkeep` placeholder from being included via the `packages` directive while still allowing it through `force-include`.
+
 ## [1.3.2] - 2026-02-22
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,11 @@ path = "src/SVG2DrawIOLib/__about__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/SVG2DrawIOLib"]
+only-include = [
+  "SVG2DrawIOLib/**/*.py",
+  "SVG2DrawIOLib/**/*.typed",
+  "SVG2DrawIOLib/py.typed",
+]
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/SVG2DrawIOLib/web" = "SVG2DrawIOLib/web"

--- a/src/SVG2DrawIOLib/__about__.py
+++ b/src/SVG2DrawIOLib/__about__.py
@@ -1,3 +1,3 @@
 """Package version information."""
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"


### PR DESCRIPTION
- Add `only-include` configuration to wheel build targeting Python files and type stubs
- Prevent `.gitkeep` placeholder from being included in wheel via `packages` directive
- Maintain `.gitkeep` in repository through `force-include` for web directory structure
- Bump version to 1.3.3
- Update CHANGELOG with fix details PyPI rejected previous wheel due to duplicate `.gitkeep` file. The `only-include` directive now explicitly specifies which files to package, preventing unintended inclusion of placeholder files while preserving the web directory structure through force-include.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-config-only change plus version/changelog bump; low risk outside of potentially affecting which files land in the published wheel.
> 
> **Overview**
> Fixes PyPI wheel build rejection by tightening hatchling wheel contents to `only-include` Python sources/type stubs, preventing the `web/.gitkeep` placeholder from being pulled in via the `packages` directive while still bundling `web/` via `force-include`.
> 
> Bumps the package version to `1.3.3` and documents the packaging fix in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f24678dcad0fbe135ef5da72042cd9055dad2000. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->